### PR TITLE
fix: 修改空指针异常问题 (#57)

### DIFF
--- a/deploy/kubernetes/polaris-sync-config.yaml
+++ b/deploy/kubernetes/polaris-sync-config.yaml
@@ -16,7 +16,7 @@ data:
     	],
     	"health_check": {
     		"enable": true
-    	},`
+    	},
     	"report": {
     		"interval" : "1m",
     		"targets": [

--- a/polaris-sync-config-plugins/config-file/src/main/java/cn/polarismesh/polaris/sync/config/plugins/file/FileConfigProvider.java
+++ b/polaris-sync-config-plugins/config-file/src/main/java/cn/polarismesh/polaris/sync/config/plugins/file/FileConfigProvider.java
@@ -24,6 +24,7 @@ import cn.polarismesh.polaris.sync.extension.config.ConfigProvider;
 import cn.polarismesh.polaris.sync.registry.pb.RegistryProto.Registry;
 import com.google.gson.Gson;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,9 @@ public class FileConfigProvider implements ConfigProvider {
     public void init(Map<String, Object> options) throws Exception {
         Gson gson = new Gson();
         Config param = gson.fromJson(gson.toJson(options), Config.class);
-
+        if (StringUtils.isBlank(param.getWatchFile())) {
+            throw new IllegalArgumentException("watchFile must be specific in ConfigFileProvider");
+        }
         fileChangeWorker = new FileChangeWorker(param.getWatchFile(), 0);
         fileWatchService.scheduleWithFixedDelay(fileChangeWorker,
                 DefaultValues.DEFAULT_FILE_PULL_MS, DefaultValues.DEFAULT_FILE_PULL_MS, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
* feat：增加configProvider的配置项，默认支持file

* feat：去掉部署配置文件的特殊字符，用户没有配置watchfile进行校验，不抛空指针